### PR TITLE
Read out the firmware version of the whitebeet and print in log

### DIFF
--- a/Ev.py
+++ b/Ev.py
@@ -10,6 +10,7 @@ class Ev():
     def __init__(self, iftype, iface, mac):
         self.logger = Logger()
         self.whitebeet = Whitebeet(iftype, iface, mac)
+        print(f"WHITE-beet-PI firmware version: {self.whitebeet.version}")
 
         self.battery = Battery()
 

--- a/Evse.py
+++ b/Evse.py
@@ -6,6 +6,7 @@ class Evse():
 
     def __init__(self, iftype, iface, mac):
         self.whitebeet = Whitebeet(iftype, iface, mac)
+        print(f"WHITE-beet-EI firmware version: {self.whitebeet.version}")
         self.charger = Charger()
         self.schedule = None
         self.evse_config = None
@@ -28,6 +29,7 @@ class Evse():
         to 100%. The SLAC module is also started. This one needs ~1s to 2s to be ready.
         Therefore we delay the initialization by 2s.
         """
+
         print("Set the CP mode to EVSE")
         self.whitebeet.controlPilotSetMode(1)
         print("Set the CP duty cycle to 100%")

--- a/Whitebeet.py
+++ b/Whitebeet.py
@@ -16,6 +16,10 @@ class Whitebeet():
         self.payloadBytesRead = 0
         self.payloadBytesLen = 0
 
+        # System sub IDs
+        self.sys_mod_id = 0x10
+        self.sys_sub_get_firmware_version = 0x41
+
         # Network configuration IDs
         self.netconf_sub_id = 0x05
         self.netconf_set_port_mirror_state = 0x55
@@ -105,6 +109,7 @@ class Whitebeet():
                 log("iface: {}, name: {}".format(iftype, iface))
 
             self.framing.clear_backlog()
+            self.version = self.systemGetVersion()
             self.slacStop()
             self.controlPilotStop()
             if self.v2gGetMode() == 1:
@@ -293,6 +298,15 @@ class Whitebeet():
         """
         if self.payloadBytesRead != self.payloadBytesLen:
             raise Warning("More payload than expected! (read: {}, length: {})".format(self.payloadBytesRead, self.payloadBytesLen))
+
+    def systemGetVersion(self):
+        """
+        Retrives the firmware version in the form x.x.x
+        """
+        response = self._sendReceiveAck(self.sys_mod_id, self.sys_sub_get_firmware_version, None)
+        self.payloadReaderInitialize(response.payload, response.payload_len)
+        version_length = self.payloadReaderReadInt(2)
+        return self.payloadReaderReadBytes(version_length).decode("utf-8")
 
     def controlPilotSetMode(self, mode):
         """


### PR DESCRIPTION
The firmware version is read out from the WHITE-beet and printed to the console. For the EV version 1.0.6:

```console
WHITE-beet-PI firmware version: V01_00_06
```