### PR TITLE
Fix frame filtering

### DIFF
--- a/FramingInterface.py
+++ b/FramingInterface.py
@@ -200,9 +200,18 @@ class FramingInterface():
 
                 if filter_sub is not None:
                     # Filter for sub ID
-                    if isinstance(filter_sub, int):
-                        filter_sub = [filter_sub]
-                    if frame.sub_id not in filter_sub:
+                    sub_id_filter_list = None
+
+                    if isinstance(filter_sub, dict):
+                        if frame.mod_id in filter_sub:
+                            sub_id_filter_list = filter_sub[frame.mod_id]
+                    else:
+                        sub_id_filter_list = filter_sub
+
+                    if isinstance(sub_id_filter_list, int):
+                        sub_id_filter_list = [sub_id_filter_list]
+
+                    if not (sub_id_filter_list == None or frame.sub_id in sub_id_filter_list):
                         satisfied = False
 
                 # for backwards compatibility
@@ -316,7 +325,7 @@ class FramingInterface():
         return request_id_num
 
     def generate_next_request_id(self):
-        if self.request_id == 255:
+        if self.request_id == 254: # Skip 0xFF as that's used for status messages
             self.request_id = 0
         else:
             self.request_id += 1

--- a/Whitebeet.py
+++ b/Whitebeet.py
@@ -166,7 +166,7 @@ class Whitebeet():
             response = None
             while loop == True:
                 req_id = self.framing.build_and_send_frame(mod_id, sub_id, payload)
-                response = self.framing.receive_next_frame(filter_mod=[mod_id, 0xFF], filter_req_id=req_id, timeout=time_end - time_start)
+                response = self.framing.receive_next_frame(filter_mod=[mod_id, 0xFF], filter_sub={ mod_id: sub_id }, filter_req_id=req_id, timeout=time_end - time_start)
                 if response is None:
                     self.connectionError = True
                     raise ConnectionError("Problem with send/receive - Please check your connection!")


### PR DESCRIPTION
- Requests now only use 0x00-0xFE for request ids. Note that 0xFF is primarily reserved for status messages and can lead to issues if used for regular requests.
- `_sendReceive` now also filters sub ids for the response.

Closes #156 